### PR TITLE
Support deploying to different swarms (beta & staging)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,10 @@ BUILD_ARGS := \
 # and maybe by the Dockerfiles is useful here, so this is currently an
 # unused variable
 OTHER_ENV_ARGS := \
+	NODE_VER \
 	MONGO_VER \
 	NGINX_VER \
+	DEPLOY_STACK \
 
 # command string which displays the values of all BUILD_ARGS
 SHOW_ENV = $(patsubst %,echo '%';,$(foreach var,$(BUILD_ARGS),$(var)=$($(var))))
@@ -122,7 +124,7 @@ stop :
 	docker-compose stop
 
 logs :
-	docker-compose logs $(SERVICE_NAME)
+	docker-compose logs $(OPTS) $(SERVICE_NAME)
 
 clean :
 	-rm $(IMAGE_DIR)/*
@@ -144,9 +146,11 @@ push-prod :
 	docker-compose $(COMPOSE_CONF_PROD) push $(SERVICE_NAME)
 
 deploy-stack :
+# require that the DEPLOY_SWARM be explicitly defined.
+	$(call ndef,DEPLOY_SWARM)
 # Setting FIREBASE_CONFIG is a hack because docker stack deploy doesn't process the .env file
 # where it is expected to be set and therefore the docker-compose.yml file causes an error.
-	FIREBASE_CONFIG='' docker stack deploy $(STACK_CONF_DEPLOY) riff-stack
+	FIREBASE_CONFIG='' docker stack deploy $(STACK_CONF_DEPLOY) -c docker-stack.$(DEPLOY_SWARM).yml riff-stack
 
 dev-server : SERVICE_NAME = riff-server
 dev-server : _start-dev

--- a/docker-stack.beta.yml
+++ b/docker-stack.beta.yml
@@ -1,0 +1,16 @@
+---
+# override/additions to docker-stack.yml for deploying to the beta swarm
+version: '3.6'
+services:
+  web-server:
+    secrets:
+      - source: beta.riffplatform.com.key.1
+        target: site.key
+      - source: beta.riffplatform.com.crt.1
+        target: site.crt
+
+secrets:
+  beta.riffplatform.com.key.1:
+    external: true
+  beta.riffplatform.com.crt.1:
+    external: true

--- a/docker-stack.staging.yml
+++ b/docker-stack.staging.yml
@@ -1,0 +1,16 @@
+---
+# override/additions to docker-stack.yml for deploying to the staging swarm
+version: '3.6'
+services:
+  web-server:
+    secrets:
+      - source: staging.riffplatform.com.key.1
+        target: site.key
+      - source: staging.riffplatform.com.crt.1
+        target: site.crt
+
+secrets:
+  staging.riffplatform.com.key.1:
+    external: true
+  staging.riffplatform.com.crt.1:
+    external: true

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -67,18 +67,9 @@ services:
         delay: 10s
       restart_policy:
         condition: on-failure
-    secrets:
-      - source: beta.riffplatform.com.key.1
-        target: site.key
-      - source: beta.riffplatform.com.crt.1
-        target: site.crt
+
 configs:
   riff-rtc.local-production.yml.3:
     external: true
   signalmaster.local-production.yml.1:
-    external: true
-secrets:
-  beta.riffplatform.com.key.1:
-    external: true
-  beta.riffplatform.com.crt.1:
     external: true


### PR DESCRIPTION
NEEDS DOCUMENTATION written!

you must define an env variable DEPLOY_SWARM with the name of the
swarm (currently beta or staging) this is used to add a final override
compose yml file defining setting specific to the swarm, currently
secret names to the command run by the make target deploy-stack.

quick summary of deploy steps (using example values):
```sh
. activate
./cloudformation.py tunnel stagingswarm
export DOCKER_HOST=localhost:2374
export DEPLOY_SWARM=staging
xargs -n 1 docker pull
nginx mongo redis node:10 mhart/alpine-node:10
CTRL-D
vim build_vars
. build_vars
make clean
make build-prod
make push-prod
make deploy-stack
```

Keep in mind that docker secrets and configs used by the deploy must exist on the swarm before you run `make deploy-stack`.