### PR TITLE
LTI support requires a redis-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ OTHER_ENV_ARGS := \
 	NODE_VER \
 	MONGO_VER \
 	NGINX_VER \
+	REDIS_VER \
 	DEPLOY_STACK \
 
 # command string which displays the values of all BUILD_ARGS

--- a/build-vars
+++ b/build-vars
@@ -10,13 +10,13 @@
 # The image tag on the built image will be the same as that ref
 # unless it doesn't work as a tag (contains a / or some other issue)
 # in which case you should change it here.
-export RIFF_RTC_REF=0.4.0-dev.13
+export RIFF_RTC_REF=0.4.0-dev.23
 export RTC_BUILD_TAG=$RIFF_RTC_REF
 export RIFF_RTC_TAG=$RTC_BUILD_TAG
 
 # Specify the github rifflearning/riff-server git commit reference for the
 # production riff-server docker image
-export RIFF_SERVER_REF=0.4.0-dev.4
+export RIFF_SERVER_REF=0.4.0-dev.5
 export RIFF_SERVER_TAG=$RIFF_SERVER_REF
 
 # Specify the github rifflearning/signalmaster git commit reference for the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
         SESSION_SECRET: secret
         CONSUMER_KEY: key
         CONSUMER_SECRET: secret
+    depends_on:
+      - redis-server
 
   web-server:
     image: '127.0.0.1:5000/rifflearning/web-server:${RIFF_RTC_TAG-dev}'
@@ -76,10 +78,9 @@ services:
     build:
       context: ${SIGNALMASTER_PATH-../signalmaster}/docker
       dockerfile: Dockerfile-dev
-    environment:
-      STUNSERVER_URL: 'stun:stun.services.mozilla.com'
-      TWILIO_ID:
-      TWILIO_TOKEN:
 
   mongo-server:
     image: mongo:${MONGO_VER-latest}
+
+  redis-server:
+    image: redis:${REDIS_VER-latest}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -33,7 +33,7 @@ services:
       restart_policy:
         condition: on-failure
     configs:
-      - source: riff-rtc.local-production.yml.3
+      - source: riff-rtc.local-production.yml.4
         target: /app/config/local-production.yml
 
   mongo-server:
@@ -78,7 +78,7 @@ services:
         condition: on-failure
 
 configs:
-  riff-rtc.local-production.yml.3:
+  riff-rtc.local-production.yml.4:
     external: true
   signalmaster.local-production.yml.1:
     external: true

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -47,6 +47,15 @@ services:
       placement:
         constraints: [node.role == manager]
 
+  redis-server:
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+
   signalmaster:
     deploy:
       replicas: 1

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -13,7 +13,8 @@ The basic usage for deployment involves:
 1. SSH tunnel to a manager in the cloudformation docker swarm you just made
 1. Initialize the swarm by making a registry and starting everything in swarm mode
 1. Build and push docker images to the remote registry in your swarm
-1. Bring your swarm up!
+1. Deploy the docker stack to the docker swarm running in the cloudformation
+   stack. (Note that there are 2 different types of stacks referenced in this step!)
 
 I go through the steps in detail below:
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -42,14 +42,31 @@ make init-server
 from the riff-docker working directory:
 
 ```sh
+. nobuild-vars
 make build-dev
 ```
 
-Re-run this command to rebuild the images. You only need to do that when
-you want to refresh the base image (ie update node w/ any new patches).
+Re-run this command to rebuild the images. Because the development images expect
+the local repository working directories to be bound to the containers, you only
+need to rebuild when you want to refresh the base image (ie update node w/ any new
+patches).
+
+It's best if you tag the development images w/ the `dev` tag, which will be set if
+you don't override it. Running `. nobuild-vars` will unset all of the environment
+variables which would set the image tags. Those environment variables are most often
+used when building production images.
+
+The `build-dev` target depends on (and therefore will create if they don't exist)
+the self-signed ssl files.
 
 ## Running
 
 run `make up` Then access `http://localhost`.
 
 The containers are started detached so use `make stop` to stop the containers.
+You can use `make down` to stop (if running) and remove the containers.
+
+### Configuration
+
+Use a `config/local-development.yml` file for local configuration settings in
+`riff-rtc` (or `config/local.yml` if you want).


### PR DESCRIPTION
## LTI Support changes
- Add redis-server service to docker-compose yaml files
- create a new `riff-rtc.local-production.yml` configuration file w/ new LTI and logging
  configuration settings.

## Other
- Update the build-vars w/ the latest versions being deployed to staging
- minor doc changes (major doc changes are still needed, but not done)